### PR TITLE
Fix run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   skip: True  # [not linux64]
 
 requirements:
-  run_constraints:
+  run_constrained:
     - protobuf {{ major_version }}.{{ version }}.*
     - libprotobuf {{ major_version }}.{{ version }}.*
 


### PR DESCRIPTION
This recipes was converted back from recipe format v1 and `run_constraints` was missed.
