### PR TITLE
v6.33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-staging_channel_upload_target: protobuf-6.33.0-build-4
-
-channels:
-  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4
-  - https://staging.continuum.io/pbp/fs/lief-feedstock/pr10/1e1d643

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+staging_channel_upload_target: protobuf-6.33.0-build-4
+
+channels:
+  - https://staging.continuum.io/pbp/protobuf-6.33.0-build-4
+  - https://staging.continuum.io/pbp/fs/lief-feedstock/pr10/1e1d643

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "29.3" %}
-{% set major_version = "5" %}
+{% set version = "33.0" %}
+{% set major_version = "6" %}
 
 package:
   name: protobuf-bazel-rules
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/releases/download/v{{ version }}/protobuf-{{ version }}.tar.gz
-    sha256: 008a11cc56f9b96679b4c285fd05f46d317d685be3ab524b2a310be0fbad987e
+    sha256: cbc536064706b628dcfe507bef386ef3e2214d563657612296f1781aa155ee07
 
 build:
   number: 0


### PR DESCRIPTION
protobuf-bazel-rules v6.33

**Destination channel:** defaults

### Links

- [PKG-10776](https://anaconda.atlassian.net/browse/PKG-10776) 

### Explanation of changes:

- Add support for our latest protobuf
    - Bump version and SHA


[PKG-10776]: https://anaconda.atlassian.net/browse/PKG-10776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ