### PR TITLE
Update version to 6.33.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "33.0" %}
+{% set version = "33.5" %}
 {% set major_version = "6" %}
 
 package:
@@ -7,12 +7,10 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/releases/download/v{{ version }}/protobuf-{{ version }}.tar.gz
-    sha256: cbc536064706b628dcfe507bef386ef3e2214d563657612296f1781aa155ee07
+    sha256: c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1
 
 build:
   number: 0
-  noarch: generic
-  skip: True  # [not linux64]
 
 requirements:
   run_constrained:
@@ -24,7 +22,7 @@ test:
     - test -f ${PREFIX}/share/bazel/protobuf/bazel/cc_proto_library.bzl  # [unix]
 
 about:
-  home: https://developers.google.com/protocol-buffers/
+  home: https://developers.google.com/protocol-buffers
   dev_url: https://github.com/protocolbuffers/protobuf
   doc_url: https://protobuf.dev/overview/
   license: BSD-3-Clause


### PR DESCRIPTION
protobuf-bazel-rules 6.33.5

**Destination channel:**  defaults

### Links

- [PKG-12445](https://anaconda.atlassian.net/browse/PKG-12445) 
- [Upstream repository](https://github.com/conda-forge/protobuf-bazel-rules-feedstock)

### Explanation of changes:

- New version number


[PKG-12445]: https://anaconda.atlassian.net/browse/PKG-12445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ